### PR TITLE
Added the ability to override reverb and chorus events like omnimidi, fix loudmax, and make conversion much faster

### DIFF
--- a/OmniConverter/Extensions/BASSMIDI.cs
+++ b/OmniConverter/Extensions/BASSMIDI.cs
@@ -165,6 +165,16 @@ namespace OmniConverter
             }
         }
 
+        public unsafe bool SendReverbEvent(int channel, int param)
+        {
+            return BassMidi.BASS_MIDI_StreamEvent(Handle, channel, BASSMIDIEvent.MIDI_EVENT_REVERB, param);
+        }
+
+        public unsafe bool SendChorusEvent(int channel, int param)
+        {
+            return BassMidi.BASS_MIDI_StreamEvent(Handle, channel, BASSMIDIEvent.MIDI_EVENT_CHORUS, param);
+        }
+
         public unsafe int SendEventRaw(uint data, int channel)
         {
             var mode = BASSMIDIEventMode.BASS_MIDI_EVENTS_RAW | BASSMIDIEventMode.BASS_MIDI_EVENTS_NORSTATUS;

--- a/OmniConverter/Extensions/Converter.cs
+++ b/OmniConverter/Extensions/Converter.cs
@@ -97,8 +97,9 @@ namespace OmniConverter
                 using (var bass = new BASSMIDI(format))
                 {
                     ISampleSource bassSource;
-                    if (loudmax) bassSource = new AntiClipping(bass, 0.1);
-                    else bassSource = bass;
+                    /*if (loudmax) bassSource = new AntiClipping(bass, 0.1);
+                    else bassSource = bass;*/
+                    bassSource = bass; //Why the hell was it running loudmax twice lol
                     float[] buffer = new float[2048 * 16];
                     long prevWriteTime = 0;
                     double time = 0;

--- a/OmniConverter/Extensions/Converter.cs
+++ b/OmniConverter/Extensions/Converter.cs
@@ -146,6 +146,15 @@ namespace OmniConverter
                         }
                         else if (e is ControlChangeEvent)
                         {
+                            if(Properties.Settings.Default.RVOverrideToggle)
+                            {
+                                for (int i = 0; i <= 15; ++i)
+                                {
+                                    bass.SendReverbEvent(i, Properties.Settings.Default.ReverbValue);
+                                    bass.SendChorusEvent(i, Properties.Settings.Default.ChorusValue);
+                                }
+                            }
+                            
                             var ev = e as ControlChangeEvent;
                             bass.SendEventRaw((uint)(0xB0 | (ev.Controller << 8) | (ev.Value << 16)), ev.Channel + 1);
                         }

--- a/OmniConverter/Extensions/Converter.cs
+++ b/OmniConverter/Extensions/Converter.cs
@@ -4,6 +4,7 @@ using MIDIModificationFramework;
 using MIDIModificationFramework.MIDIEvents;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -149,7 +150,7 @@ namespace OmniConverter
                         {
                             if(Properties.Settings.Default.RVOverrideToggle)
                             {
-                                for (int i = 0; i <= 15; ++i)
+                                for(int i = 0; i <= 15; i++)
                                 {
                                     bass.SendReverbEvent(i, Properties.Settings.Default.ReverbValue);
                                     bass.SendChorusEvent(i, Properties.Settings.Default.ChorusValue);
@@ -433,12 +434,12 @@ namespace OmniConverter
                         ParallelOptions PO = new ParallelOptions { MaxDegreeOfParallelism = MT, CancellationToken = CTS.Token };
                         Debug.PrintToConsole("ok", String.Format("ParallelOptions prepared, MaxDegreeOfParallelism = {0}", MT));
 
-                        Parallel.For(0, MFile.Tracks, PO, (T, LS) =>
+                        ParallelFor(0, MFile.Tracks, Environment.ProcessorCount, new CancellationToken(false), T =>
                         {
                             if (StopRequested)
                             {
                                 Debug.PrintToConsole("ok", "Stop requested. Stopping Parallel.For...");
-                                LS.Stop();
+                                //LS.Stop();
                                 return;
                             }
 
@@ -584,6 +585,42 @@ namespace OmniConverter
 
             if (!StopRequested && !IsCrash)
                 Form.Invoke((MethodInvoker)delegate { ((Form)Form).Close(); });
+        }
+
+        static void ParallelFor(int from, int to, int threads, CancellationToken cancel, Action<int> func)
+        {
+            Dictionary<int, Task> tasks = new Dictionary<int, Task>();
+            BlockingCollection<int> completed = new BlockingCollection<int>();
+
+            void RunTask(int i)
+            {
+                var t = new Task(() =>
+                {
+                    try
+                    {
+                        func(i);
+                        completed.Add(i);
+                    }
+                    catch (Exception e) { }
+                });
+                tasks.Add(i, t);
+                t.Start();
+            }
+
+            void TryTake()
+            {
+                var t = completed.Take(cancel);
+                tasks[t].Wait();
+                tasks.Remove(t);
+            }
+
+            for (int i = from; i < to; i++)
+            {
+                RunTask(i);
+                if (tasks.Count > threads) TryTake();
+            }
+
+            while (completed.Count > 0 || tasks.Count > 0) TryTake();
         }
     }
 }

--- a/OmniConverter/Forms/MainWindow.cs
+++ b/OmniConverter/Forms/MainWindow.cs
@@ -53,7 +53,7 @@ namespace OmniConverter
 
             MIDIQueue.DataSource = null;
             MIDIQueue.DataSource = Program.MIDIList;
-            MIDIQueue.DisplayMember = "GetName";
+            MIDIQueue.DisplayMember = "Name";
 
             Debug.PrintToConsole("ok", "MIDIQueue bound successfully.");
         }

--- a/OmniConverter/Forms/Settings.Designer.cs
+++ b/OmniConverter/Forms/Settings.Designer.cs
@@ -29,6 +29,8 @@
         private void InitializeComponent()
         {
             this.AudioSettings = new System.Windows.Forms.GroupBox();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.EnableRCOverride = new System.Windows.Forms.CheckBox();
             this.EnableLoudMax = new System.Windows.Forms.CheckBox();
             this.NoteOff1 = new System.Windows.Forms.CheckBox();
             this.FXDisable = new System.Windows.Forms.CheckBox();
@@ -53,17 +55,25 @@
             this.PostConvSettings = new System.Windows.Forms.GroupBox();
             this.DoActionAfterRenderVal = new System.Windows.Forms.ComboBox();
             this.DoActionAfterRender = new System.Windows.Forms.CheckBox();
+            this.ReverbL = new System.Windows.Forms.Label();
+            this.ReverbV = new System.Windows.Forms.NumericUpDown();
+            this.ChorusV = new System.Windows.Forms.NumericUpDown();
+            this.ChorusL = new System.Windows.Forms.Label();
             this.AudioSettings.SuspendLayout();
+            this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MaxVoices)).BeginInit();
             this.EventsSettings.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MTLimitVal)).BeginInit();
             this.PostConvSettings.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ReverbV)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ChorusV)).BeginInit();
             this.SuspendLayout();
             // 
             // AudioSettings
             // 
             this.AudioSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.AudioSettings.Controls.Add(this.groupBox1);
             this.AudioSettings.Controls.Add(this.EnableLoudMax);
             this.AudioSettings.Controls.Add(this.NoteOff1);
             this.AudioSettings.Controls.Add(this.FXDisable);
@@ -75,10 +85,36 @@
             this.AudioSettings.Controls.Add(this.Label6);
             this.AudioSettings.Location = new System.Drawing.Point(14, 14);
             this.AudioSettings.Name = "AudioSettings";
-            this.AudioSettings.Size = new System.Drawing.Size(430, 187);
+            this.AudioSettings.Size = new System.Drawing.Size(430, 266);
             this.AudioSettings.TabIndex = 0;
             this.AudioSettings.TabStop = false;
             this.AudioSettings.Text = "Audio settings";
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.ChorusV);
+            this.groupBox1.Controls.Add(this.ChorusL);
+            this.groupBox1.Controls.Add(this.ReverbV);
+            this.groupBox1.Controls.Add(this.ReverbL);
+            this.groupBox1.Controls.Add(this.EnableRCOverride);
+            this.groupBox1.Location = new System.Drawing.Point(6, 185);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(415, 73);
+            this.groupBox1.TabIndex = 46;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Control Event Override";
+            // 
+            // EnableRCOverride
+            // 
+            this.EnableRCOverride.AutoSize = true;
+            this.EnableRCOverride.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.EnableRCOverride.Location = new System.Drawing.Point(6, 22);
+            this.EnableRCOverride.Name = "EnableRCOverride";
+            this.EnableRCOverride.Size = new System.Drawing.Size(240, 20);
+            this.EnableRCOverride.TabIndex = 45;
+            this.EnableRCOverride.Text = "Override MIDI reverb and chrous events";
+            this.EnableRCOverride.UseVisualStyleBackColor = true;
+            this.EnableRCOverride.CheckedChanged += new System.EventHandler(this.EnableRCOverride_CheckedChanged);
             // 
             // EnableLoudMax
             // 
@@ -222,7 +258,7 @@
             this.EventsSettings.Controls.Add(this.PerTrackStorage);
             this.EventsSettings.Controls.Add(this.PerTrackExportEach);
             this.EventsSettings.Controls.Add(this.MTMode);
-            this.EventsSettings.Location = new System.Drawing.Point(14, 208);
+            this.EventsSettings.Location = new System.Drawing.Point(14, 286);
             this.EventsSettings.Name = "EventsSettings";
             this.EventsSettings.Size = new System.Drawing.Size(430, 205);
             this.EventsSettings.TabIndex = 1;
@@ -357,7 +393,7 @@
             // 
             this.OkBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.OkBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.OkBtn.Location = new System.Drawing.Point(370, 510);
+            this.OkBtn.Location = new System.Drawing.Point(370, 582);
             this.OkBtn.Name = "OkBtn";
             this.OkBtn.Size = new System.Drawing.Size(75, 23);
             this.OkBtn.TabIndex = 3;
@@ -371,7 +407,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.PostConvSettings.Controls.Add(this.DoActionAfterRenderVal);
             this.PostConvSettings.Controls.Add(this.DoActionAfterRender);
-            this.PostConvSettings.Location = new System.Drawing.Point(14, 419);
+            this.PostConvSettings.Location = new System.Drawing.Point(14, 497);
             this.PostConvSettings.Name = "PostConvSettings";
             this.PostConvSettings.Size = new System.Drawing.Size(430, 79);
             this.PostConvSettings.TabIndex = 4;
@@ -405,11 +441,58 @@
             this.DoActionAfterRender.UseVisualStyleBackColor = true;
             this.DoActionAfterRender.CheckedChanged += new System.EventHandler(this.DoActionAfterRender_CheckedChanged);
             // 
+            // ReverbL
+            // 
+            this.ReverbL.AutoSize = true;
+            this.ReverbL.BackColor = System.Drawing.SystemColors.Control;
+            this.ReverbL.Enabled = false;
+            this.ReverbL.Location = new System.Drawing.Point(4, 49);
+            this.ReverbL.Name = "ReverbL";
+            this.ReverbL.Size = new System.Drawing.Size(83, 15);
+            this.ReverbL.TabIndex = 46;
+            this.ReverbL.Text = "Reverb (0-127)";
+            // 
+            // ReverbV
+            // 
+            this.ReverbV.Enabled = false;
+            this.ReverbV.Location = new System.Drawing.Point(91, 46);
+            this.ReverbV.Maximum = new decimal(new int[] {
+            127,
+            0,
+            0,
+            0});
+            this.ReverbV.Name = "ReverbV";
+            this.ReverbV.Size = new System.Drawing.Size(39, 23);
+            this.ReverbV.TabIndex = 47;
+            // 
+            // ChorusV
+            // 
+            this.ChorusV.Enabled = false;
+            this.ChorusV.Location = new System.Drawing.Point(218, 46);
+            this.ChorusV.Maximum = new decimal(new int[] {
+            127,
+            0,
+            0,
+            0});
+            this.ChorusV.Name = "ChorusV";
+            this.ChorusV.Size = new System.Drawing.Size(39, 23);
+            this.ChorusV.TabIndex = 49;
+            // 
+            // ChorusL
+            // 
+            this.ChorusL.AutoSize = true;
+            this.ChorusL.Enabled = false;
+            this.ChorusL.Location = new System.Drawing.Point(131, 49);
+            this.ChorusL.Name = "ChorusL";
+            this.ChorusL.Size = new System.Drawing.Size(85, 15);
+            this.ChorusL.TabIndex = 48;
+            this.ChorusL.Text = "Chorus (0-127)";
+            // 
             // Settings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(458, 546);
+            this.ClientSize = new System.Drawing.Size(458, 618);
             this.ControlBox = false;
             this.Controls.Add(this.PostConvSettings);
             this.Controls.Add(this.OkBtn);
@@ -426,12 +509,16 @@
             this.Load += new System.EventHandler(this.Settings_Load);
             this.AudioSettings.ResumeLayout(false);
             this.AudioSettings.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MaxVoices)).EndInit();
             this.EventsSettings.ResumeLayout(false);
             this.EventsSettings.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.MTLimitVal)).EndInit();
             this.PostConvSettings.ResumeLayout(false);
             this.PostConvSettings.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ReverbV)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ChorusV)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -463,5 +550,11 @@
         private System.Windows.Forms.GroupBox PostConvSettings;
         private System.Windows.Forms.ComboBox DoActionAfterRenderVal;
         private System.Windows.Forms.CheckBox DoActionAfterRender;
+        private System.Windows.Forms.GroupBox groupBox1;
+        internal System.Windows.Forms.CheckBox EnableRCOverride;
+        private System.Windows.Forms.Label ReverbL;
+        private System.Windows.Forms.NumericUpDown ChorusV;
+        private System.Windows.Forms.Label ChorusL;
+        private System.Windows.Forms.NumericUpDown ReverbV;
     }
 }

--- a/OmniConverter/Forms/Settings.cs
+++ b/OmniConverter/Forms/Settings.cs
@@ -21,6 +21,10 @@ namespace OmniConverter
             NoteOff1.Checked = Properties.Settings.Default.NoteOff1;
             EnableLoudMax.Checked = Properties.Settings.Default.LoudMax;
 
+            EnableRCOverride.Checked = Properties.Settings.Default.RVOverrideToggle;
+            ReverbV.Value = Properties.Settings.Default.ReverbValue;
+            ChorusV.Value = Properties.Settings.Default.ChorusValue;
+
             MTMode.Checked = Properties.Settings.Default.MultiThreadedMode;
             PerTrackMode.Checked = Properties.Settings.Default.PerTrackExport;
             PerTrackExportEach.Checked = Properties.Settings.Default.PerTrackSeparateFiles;
@@ -87,6 +91,14 @@ namespace OmniConverter
             DoActionAfterRenderVal.Enabled = DoActionAfterRender.Checked;
         }
 
+        private void EnableRCOverride_CheckedChanged(object sender, EventArgs e)
+        {
+            ReverbL.Enabled = EnableRCOverride.Checked;
+            ReverbV.Enabled = EnableRCOverride.Checked;
+            ChorusL.Enabled = EnableRCOverride.Checked;
+            ChorusV.Enabled = EnableRCOverride.Checked;
+        }
+
         private void OkBtn_Click(object sender, EventArgs e)
         {
             Properties.Settings.Default.VoiceLimit = (Int32)MaxVoices.Value;
@@ -96,6 +108,10 @@ namespace OmniConverter
             Properties.Settings.Default.DisableEffects = FXDisable.Checked;
             Properties.Settings.Default.NoteOff1 = NoteOff1.Checked;
             Properties.Settings.Default.LoudMax = EnableLoudMax.Checked;
+
+            Properties.Settings.Default.RVOverrideToggle = EnableRCOverride.Checked;
+            Properties.Settings.Default.ReverbValue = (Int32)ReverbV.Value;
+            Properties.Settings.Default.ChorusValue = (Int32)ChorusV.Value;
 
             Properties.Settings.Default.MultiThreadedMode = MTMode.Checked;
             Properties.Settings.Default.PerTrackExport = PerTrackMode.Checked;

--- a/OmniConverter/Properties/Settings.Designer.cs
+++ b/OmniConverter/Properties/Settings.Designer.cs
@@ -22,7 +22,56 @@ namespace OmniConverter.Properties {
                 return defaultInstance;
             }
         }
+
+        //start of added code
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool RVOverrideToggle
+        {
+            get
+            {
+                return ((bool)(this["RVOverrideToggle"]));
+            }
+            set
+            {
+                this["RVOverrideToggle"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int ReverbValue
+        {
+            get
+            {
+                return ((int)(this["ReverbValue"]));
+            }
+            set
+            {
+                this["ReverbValue"] = value;
+            }
+        }
         
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int ChorusValue
+        {
+            get
+            {
+                return ((int)(this["ChorusValue"]));
+            }
+            set
+            {
+                this["ChorusValue"] = value;
+            }
+        }
+
+        //end of added code
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]


### PR DESCRIPTION
This is just a simple update that allows users to override reverb and chorus events just like how you can do it in OmniMIDI

We also made it not do a redundant loudmax pass when converting, and we made per track multi threaded conversion much faster by replacing the parallel for loop with a custom parallel for loop made for zenith