### PR TITLE
XSynth related fixes

### DIFF
--- a/OmniConverter/Extensions/Audio/MIDIRenderer.cs
+++ b/OmniConverter/Extensions/Audio/MIDIRenderer.cs
@@ -51,6 +51,7 @@ namespace OmniConverter
         public abstract void SendEvent(byte[] data);
         public abstract unsafe int Read(float[] buffer, int offset, long delta, int count);
         public abstract void RefreshInfo();
+        public abstract void SendEndEvent();
         public abstract long Position { get; set; }
         public abstract long Length { get; }
 

--- a/OmniConverter/Extensions/Audio/Renderers/BASSRenderer.cs
+++ b/OmniConverter/Extensions/Audio/Renderers/BASSRenderer.cs
@@ -322,6 +322,17 @@ namespace OmniConverter
             RenderingTime = output;
         }
 
+        public override void SendEndEvent()
+        {
+            var ev = new[]
+            {
+                new MidiEvent() {EventType = MidiEventType.EndTrack, Channel = 0, Parameter = 0, Position = 0, Ticks = 0 },
+                new MidiEvent() {EventType = MidiEventType.End, Channel = 0, Parameter = 0, Position = 0, Ticks = 0 },
+            };
+
+            BassMidi.StreamEvents(Handle, MidiEventsMode.Raw | MidiEventsMode.Struct, ev);
+        }
+
         public override long Position
         {
             get { return Bass.ChannelGetPosition(Handle) / 4; }

--- a/OmniConverter/Extensions/MIDI/MIDIConverter.cs
+++ b/OmniConverter/Extensions/MIDI/MIDIConverter.cs
@@ -1037,14 +1037,12 @@ namespace OmniConverter
                         }
                     }
 
-                    var fl = 1.0f;
+                    _midiRenderer.SendEndEvent();
 
-                    while (fl != 0.0f)
+                    while (_midiRenderer.ActiveVoices > 0)
                     {
                         _midiRenderer.Read(buffer, 0, 0, buffer.Length);
                         output.Write(buffer, 0, buffer.Length);
-
-                        fl = buffer[0];
                     }
                 }
 


### PR DESCRIPTION
- Added back the `SendEndEvent` function and added a check for voices instead of audio samples to finish a render (fixes some MIDIs getting stalled after finishing rendering)
- Fixed struct size related crashes (specified Interpolation and ChannelCount enum types)
- Remove nonexistent API functions
- Fixed the fade out killing option to work as expected
- Other very small fixes

I also have some other comments about how OC handles certain things that I will specify below.